### PR TITLE
Add support for named use block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,5 @@ test:
 	@echo Running unit tests.
 	@python3 -m doctest main.py && echo All unit tests passed!
 	@echo
-	@echo Running examples.py. Expected output is "1 2 3" three times.
+	@echo Running examples.py. Expected output is "1 2 3" several times.
 	@python3 main.py examples.py | python3

--- a/examples.py
+++ b/examples.py
@@ -8,7 +8,6 @@ def example0():
         result = b + 1
         return result
     print(a, b, c)
-example0()
 
 def example1():
     # - two parameters
@@ -19,10 +18,9 @@ def example1():
     use a, b:
         c = b + 1
         print(a, b, c)
-example1()
 
 def example2():
-    # no parameters: should raise exception
+    # ignores enclosing scope
     a = 99
     use:
         try:
@@ -30,7 +28,6 @@ def example2():
         except NameError:
             pass
         print(1, 2, 3)
-example2()
 
 def example3():
     # empty line inside block should be handled correctly
@@ -39,4 +36,35 @@ def example3():
 
         return my_list
     print(a, b, c)
+
+def example4():
+    # named use block
+    a = 3
+    a, b, c = use my_range(a):
+        if a == 1:
+            return [1]
+        else:
+            return my_range(a - 1) + [a]
+    print(a, b, c)
+
+def example5():
+    # named use block with no params
+    a, b, c = use my_range2():
+        return [1, 2, 3]
+    print(a, b, c)
+
+def example6():
+    # named use block with multiple params
+    a = 1
+    b = 2
+    c = use get_c(a, b):
+        return a + b
+    print(a, b, c)
+
+example0()
+example1()
+example2()
 example3()
+example4()
+example5()
+example6()


### PR DESCRIPTION
This is useful for recursion.

Also in this commit:
- Change 'id' concept to 'name'
- Rename parameters to params
- Change my_string[:-1] to my_string.rstrip(whatever)